### PR TITLE
fix: sanitise text strings to remove escaped characters and null bytes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: uv run pytest
+        entry: .venv/bin/python -m pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clinical-mining"
-version = "0.6.4"
+version = "0.7.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/clinical_mining/data_sources/aact/llm_extractor.py
+++ b/src/clinical_mining/data_sources/aact/llm_extractor.py
@@ -15,6 +15,7 @@ from clinical_mining.schemas import (
     ExtractedDisease,
     ExtractedDrug,
 )
+from clinical_mining.utils.text_cleaning import sanitise_nested
 from clinical_mining.workflows.llm import _extractions_to_df
 
 
@@ -186,7 +187,7 @@ def _parse_single_record(
         }
 
     try:
-        payload = json.loads(text)
+        payload = sanitise_nested(json.loads(text))
     except json.JSONDecodeError as e:
         return None, {
             "file": path,

--- a/src/clinical_mining/dataset/clinical_report.py
+++ b/src/clinical_mining/dataset/clinical_report.py
@@ -157,10 +157,12 @@ class ClinicalReport:
         df = self.drop_duplicates(df)
 
         df = df.with_columns(
-            # Apply sanitise_text to all string columns
+            # Apply sanitise_text to all top-level string columns. Strings nested
+            # inside structs or lists (drugs, diseases, sideEffects, countries) are
+            # not reached by `pl.col(pl.String)`; those originate from the LLM output
+            # and are already sanitised by `sanitise_nested` when the batch results are parsed.
             pl.col(pl.String).map_elements(sanitise_text, return_dtype=pl.String)
         )
-
         self.df = validate_schema(df, ClinicalReportSchema)
 
     def pipe(self, func: callable, *args, **kwargs) -> "ClinicalReport":

--- a/src/clinical_mining/dataset/clinical_report.py
+++ b/src/clinical_mining/dataset/clinical_report.py
@@ -9,6 +9,7 @@ from clinical_mining.schemas import (
     validate_schema,
 )
 from clinical_mining.utils.mapping import map_entities
+from clinical_mining.utils.text_cleaning import sanitise_text
 
 # Clinical status harmonization constants
 PHASE_TO_CATEGORY_MAP = {
@@ -154,6 +155,11 @@ class ClinicalReport:
 
         # Drop duplicates by id, keeping the row with the best clinical stage
         df = self.drop_duplicates(df)
+
+        df = df.with_columns(
+            # Apply sanitise_text to all string columns
+            pl.col(pl.String).map_elements(sanitise_text, return_dtype=pl.String)
+        )
 
         self.df = validate_schema(df, ClinicalReportSchema)
 

--- a/src/clinical_mining/utils/text_cleaning.py
+++ b/src/clinical_mining/utils/text_cleaning.py
@@ -1,0 +1,22 @@
+import re
+
+
+def sanitise_text(value: str | None) -> str | None:
+    """Sanitise a string by removing null bytes and escaped characters."""
+    if value is None:
+        return None
+    value = re.sub(r"\x00([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), value)
+    value = value.replace("\x00", "")
+    value = re.sub(r"\\([\[\]><&~_^*])", r"\1", value)
+    return value
+
+
+def sanitise_nested(obj):
+    """Recursively sanitise a nested object (dict/list/str)."""
+    if isinstance(obj, str):
+        return sanitise_text(obj)
+    if isinstance(obj, dict):
+        return {k: sanitise_nested(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitise_nested(v) for v in obj]
+    return obj

--- a/tests/utils/test_text_cleaning.py
+++ b/tests/utils/test_text_cleaning.py
@@ -1,0 +1,76 @@
+from clinical_mining.utils.text_cleaning import sanitise_nested, sanitise_text
+
+
+class TestSanitiseText:
+    """Unit tests for sanitise_text."""
+
+    def test_null_byte_reconstructs_accented_e(self):
+        assert sanitise_text("S\x00e9zary syndrome") == "Sézary syndrome"
+
+    def test_null_byte_reconstructs_accented_o(self):
+        assert sanitise_text("Sj\x00f6gren") == "Sjögren"
+
+    def test_null_byte_reconstructs_registered_trademark(self):
+        assert sanitise_text("Technospiron\x00AE") == "Technospiron®"
+
+    def test_orphan_null_byte_removed(self):
+        assert sanitise_text("te\x00st") == "test"
+
+    def test_aact_unescapes_left_square_bracket(self):
+        assert sanitise_text(r"pain \[hyperalgesia\]") == "pain [hyperalgesia]"
+
+    def test_aact_unescapes_less_than(self):
+        assert sanitise_text(r"platelets \<= 30x109/L") == "platelets <= 30x109/L"
+
+    def test_aact_unescapes_greater_than(self):
+        assert sanitise_text(r"\> 5 cm") == "> 5 cm"
+
+    def test_aact_unescapes_ampersand(self):
+        assert sanitise_text(r"K\&L grade 3") == "K&L grade 3"
+
+    def test_aact_unescapes_tilde(self):
+        assert sanitise_text(r"foo \~ bar") == "foo ~ bar"
+
+    def test_aact_unescapes_underscore(self):
+        assert sanitise_text(r"foo \_ bar") == "foo _ bar"
+
+    def test_aact_unescapes_asterisk(self):
+        assert sanitise_text(r"foo \* bar") == "foo * bar"
+
+    def test_already_clean_text_is_idempotent(self):
+        assert sanitise_text("Sézary") == "Sézary"
+        assert sanitise_text("pain [hyperalgesia]") == "pain [hyperalgesia]"
+
+    def test_garbled_null_byte_removed_but_no_reconstruction(self):
+        assert sanitise_text("s\x00zary") == "szary"
+
+
+class TestSanitiseNested:
+    """Unit tests for sanitise_nested."""
+
+    def test_dict_with_string_values(self):
+        data = {"name": "S\x00e9zary", "quote": r"pain \[test\]"}
+        expected = {"name": "Sézary", "quote": "pain [test]"}
+        assert sanitise_nested(data) == expected
+
+    def test_list_of_strings(self):
+        data = ["S\x00e9zary", r"K\&L"]
+        expected = ["Sézary", "K&L"]
+        assert sanitise_nested(data) == expected
+
+    def test_deeply_nested_structure(self):
+        data = {"a": [{"b": "S\x00e9zary", "c": [r"foo \* bar"]}]}
+        expected = {"a": [{"b": "Sézary", "c": ["foo * bar"]}]}
+        assert sanitise_nested(data) == expected
+
+    def test_non_string_values_pass_through_unchanged(self):
+        data = {"x": 42, "y": None, "z": True, "w": 3.14}
+        assert sanitise_nested(data) == data
+
+    def test_mixed_list_preserves_types(self):
+        data = ["text", 42, None, ["nested"]]
+        expected = ["text", 42, None, ["nested"]]
+        assert sanitise_nested(data) == expected
+
+    def test_plain_string(self):
+        assert sanitise_nested("S\x00e9zary") == "Sézary"

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "clinical-mining"
-version = "0.6.4"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
## Context

We've seen AACT db has escaped characters in the `descriptions` field of the `brief_summaries` table that posed problems in the past.

Also, as reported by several users, the JSONs from the LLM results has escape sequences that upon loading with `json.loads()`, are interpreted as embedded null bytes.

## Fix
To account for these issues, I have applied a sanitising function in 2 places:
1. In the `clinical_report` constructor: any column containing a string will be sanitised. This is to account for any potential issues we might encounter in the future when we integrate other sources
2. In the `parse_batch_results` function: we sanitise every json object by applying the sanitising function recursively

By fixing the problem in the library, no downstream applications will have to handle these cases.

## To be done
- No necessary changes in PTS's `clinical_report` (other than updating the library version)
- The `chembl_drug` PTS step ingest the LLM outputs without using `parse_batch_results`. I will have to change the logic to use this function instead or add the sanitisation on the Spark df directly

Closes https://github.com/opentargets/issues/issues/4376