### PR TITLE
fix(aact): recover extractions split across multiple batch output items

### DIFF
--- a/src/clinical_mining/data_sources/aact/llm_extractor.py
+++ b/src/clinical_mining/data_sources/aact/llm_extractor.py
@@ -166,10 +166,30 @@ def _normalise_drug_list(items: list | None) -> list[dict]:
     return [_normalise_drug(x) for x in items if isinstance(x, dict)]
 
 
+def _message_texts(outer: dict) -> list[str]:
+    """Collect every text payload carried by a batch envelope.
+
+    The batch API can split one response across several ``output`` items, a
+    truncated fragment followed by a continuation, so ``output[0]`` is not
+    reliably the complete payload. Every ``message`` item is walked, in order,
+    and every text content entry is returned as a candidate.
+    """
+    return [
+        content["text"]
+        for item in outer["response"]["body"]["output"]
+        if item.get("type") == "message"
+        for content in (item.get("content") or [])
+        if "text" in content
+    ]
+
+
 def _parse_single_record(
     outer: dict, path: str = "<test>", row_idx: int = 0
 ) -> tuple[ClinicalReportExtractionSchema | None, dict | None]:
     """Parse a single decoded JSONL envelope into a typed extraction object.
+
+    The first candidate payload that decodes to a JSON object wins; a record is
+    only rejected when none of them does.
 
     Returns (ClinicalReportExtractionSchema, None) on success,
     (None, bad_record_dict) on failure.
@@ -177,7 +197,9 @@ def _parse_single_record(
     record_id = outer.get("custom_id", "")
 
     try:
-        text = outer["response"]["body"]["output"][0]["content"][0]["text"]
+        texts = _message_texts(outer)
+        if not texts:
+            raise ValueError("no message output with text content")
     except Exception as e:
         return None, {
             "file": path,
@@ -186,14 +208,27 @@ def _parse_single_record(
             "error": f"missing_text_path: {e}",
         }
 
-    try:
-        payload = sanitise_nested(json.loads(text))
-    except json.JSONDecodeError as e:
+    payload = None
+    last_error: Exception | None = None
+    for text in texts:
+        try:
+            candidate = sanitise_nested(json.loads(text))
+        except json.JSONDecodeError as e:
+            last_error = e
+            continue
+        if isinstance(candidate, dict):
+            payload = candidate
+            break
+        last_error = ValueError(
+            f"expected a JSON object, got {type(candidate).__name__}"
+        )
+
+    if payload is None:
         return None, {
             "file": path,
             "row_idx": row_idx,
             "id": record_id,
-            "error": f"inner_json_error: {e}",
+            "error": f"inner_json_error: {last_error}",
         }
 
     try:

--- a/tests/test_llm_extraction.py
+++ b/tests/test_llm_extraction.py
@@ -456,3 +456,107 @@ class TestParseSingleRecord:
 
         assert good is None
         assert "inner_json_error" in bad["error"]
+
+    # ── multi-item output ─────────────────────────────────────────────────────
+
+    def _message_item(self, text: str) -> dict:
+        return {
+            "id": "msg_test",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text}],
+        }
+
+    def _valid_text(self) -> str:
+        return json.loads(self.SAMPLE_LINE)["response"]["body"]["output"][0]["content"][
+            0
+        ]["text"]
+
+    def test_single_output_item_still_parses(self):
+        """A record with one output item is unaffected by the fallback."""
+        outer = json.loads(self.SAMPLE_LINE)
+        assert len(outer["response"]["body"]["output"]) == 1
+
+        good, bad = _parse_single_record(outer)
+
+        assert bad is None
+        assert good.id == "nct00031889"
+        assert len(good.investigated_drugs) == 2
+
+    def test_truncated_first_item_falls_back_to_continuation(self):
+        """A cut-off first item must not discard the complete later payload."""
+        text = self._valid_text()
+        outer = json.loads(self.SAMPLE_LINE)
+        outer["response"]["body"]["output"] = [
+            self._message_item(text[:287]),  # unterminated string
+            self._message_item(text),
+        ]
+
+        good, bad = _parse_single_record(outer)
+
+        assert bad is None
+        assert good.id == "nct00031889"
+        assert good.drug_intent == "therapeutic"
+        assert {d.drug for d in good.investigated_drugs} == {
+            "exemestane",
+            "bicalutamide",
+        }
+
+    def test_multiple_texts_within_one_item_are_candidates(self):
+        """Fragments split across content entries of a single item also count."""
+        text = self._valid_text()
+        outer = json.loads(self.SAMPLE_LINE)
+        outer["response"]["body"]["output"][0]["content"] = [
+            {"type": "output_text", "text": text[:287]},
+            {"type": "output_text", "text": text},
+        ]
+
+        good, bad = _parse_single_record(outer)
+
+        assert bad is None
+        assert good.id == "nct00031889"
+
+    def test_no_valid_payload_anywhere_returns_bad_record(self):
+        """Every fragment truncated → still a bad record, with the same error."""
+        text = self._valid_text()
+        outer = json.loads(self.SAMPLE_LINE)
+        outer["response"]["body"]["output"] = [
+            self._message_item(text[:287]),
+            self._message_item(text[:412]),
+        ]
+
+        good, bad = _parse_single_record(outer)
+
+        assert good is None
+        assert bad["id"] == "nct00031889"
+        assert "inner_json_error" in bad["error"]
+
+    def test_non_message_output_item_is_skipped(self):
+        """Only items of type 'message' are considered."""
+        text = self._valid_text()
+        outer = json.loads(self.SAMPLE_LINE)
+        outer["response"]["body"]["output"] = [
+            {
+                "id": "rs_test",
+                "type": "reasoning",
+                "content": [{"type": "reasoning_text", "text": "{not valid json"}],
+            },
+            self._message_item(text),
+        ]
+
+        good, bad = _parse_single_record(outer)
+
+        assert bad is None
+        assert good.id == "nct00031889"
+
+    def test_only_non_message_items_returns_missing_text_path(self):
+        outer = json.loads(self.SAMPLE_LINE)
+        outer["response"]["body"]["output"] = [
+            {"id": "rs_test", "type": "reasoning", "content": []},
+        ]
+
+        good, bad = _parse_single_record(outer)
+
+        assert good is None
+        assert "missing_text_path" in bad["error"]


### PR DESCRIPTION
## Problem

`_parse_single_record` reads exactly one path out of the OpenAI batch envelope:

```python
text = outer["response"]["body"]["output"][0]["content"][0]["text"]
```

If *that* text is not valid JSON, the **entire record is discarded** as an
`inner_json_error`. But the batch API can emit a response as several output
items — a truncated fragment followed by a continuation — so item `[0]` is not
reliably the complete payload. The failures look like
`inner_json_error: Unterminated string starting at: line 1 column 287`: item
`[0]` is cut off mid-JSON and the complete payload sits in a later item.

## Evidence, measured on the real AACT corpus (32 files, 233,124 lines)

| | count |
| --- | --- |
| lines carrying more than one message/content text | **557** |
| …on which `output[0].content[0].text` fails to parse | **557 — all of them** |
| …of those, with exactly one valid payload later in `output` | **539** |
| …with no valid payload anywhere | 18 |
| lines where any row carries **two or more** valid payloads | **0** |

Because no row ever carries two valid payloads, taking the first item that
parses is unambiguous — there is never a choice to be made between two
candidates.

Downstream, 66 `(molecule, candidate, trial)` evidence triples are lost across
37 trials and 55 molecules, with **zero** lost in the other direction. Four of
those cross a `MIN_TRIALS = 2` threshold and silently drop published drug
synonyms.

## Fix

Walk every `output` item **of type `message`**, in order, and every text content
entry within it; return the first candidate that decodes to a JSON object.
Report `inner_json_error` only when none does. This matches the behaviour of the
now-superseded pyspark implementation in the consuming project, which exploded
`response.body.output`, filtered on `out.type == 'message'`, exploded
`out.content`, and decoded each entry independently. The current code does not
check `type` at all; the fix adds that filter.

The `(good_record, None)` / `(None, bad_record)` contract and the existing
`missing_text_path` / `inner_json_error` / `model_validation_error` strings are
unchanged.

## Verification

Replaying the full corpus through the pre-fix and post-fix parser:

```
total lines            : 233124
old good / bad         : 232483 / 641
new good / bad         : 233022 / 102
recovered (bad -> good): 539
regressed (good -> bad): 0
```

All 539 are recovered on real data, with no record that previously parsed now
failing. The remaining 102 bad records include the 18 rows with no valid payload
anywhere, which are still correctly reported.

Test suite: **66 passed** (6 new, no existing test modified). New coverage:

- truncated first item with a valid continuation (the 557)
- fragments split across content entries of a single item
- no valid payload anywhere → still reports a bad record (the 18)
- a normal single-item record → unchanged
- a non-`message` output item → skipped
- only non-`message` items → `missing_text_path`

## Other consumer

`parse_batch_results` is also called by the `clinical_report` step in
`opentargets/pipeline`, which has shipped with this behaviour in production.
That step will pick up the recovered records once it moves to a release
containing this change.
