### PR TITLE
feat(clinical_report):  reshape `trialLiterature` to include reference type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clinical-mining"
-version = "0.7.0"
+version = "0.8.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -51,4 +51,3 @@ dev = [
 
 [tool.ruff.lint]
 select = ["F", "I"]
-

--- a/src/clinical_mining/data_sources/aact/clinical_report.py
+++ b/src/clinical_mining/data_sources/aact/clinical_report.py
@@ -134,7 +134,7 @@ def extract_clinical_report(
                         if all(col in metadata_df.columns for col in struct_cols):
                             struct_expr = pl.struct(
                                 [
-                                    pl.col(str(col)).alias(str(field))
+                                    pl.col(str(col)).cast(pl.String).alias(str(field))
                                     for field, col in spec["struct"].items()
                                 ]
                             )

--- a/src/clinical_mining/data_sources/pubmed.py
+++ b/src/clinical_mining/data_sources/pubmed.py
@@ -103,7 +103,7 @@ def build_publications_map(
     for record in records:
         nct_id = record["id"]
         trial_pmids = [
-            str(pmid) for pmid in (record.get("trialLiterature") or [])[:max_pubs]
+            str(ref["id"]) for ref in (record.get("trialLiterature") or [])[:max_pubs]
         ]
         if trial_pmids:
             selected_pmids_by_trial[nct_id] = trial_pmids

--- a/src/clinical_mining/recipe/aact_llm_extractor.yaml
+++ b/src/clinical_mining/recipe/aact_llm_extractor.yaml
@@ -68,9 +68,13 @@ workflow:
           conditions: $conditions
           additional_metadata: [$brief_summaries, $study_references, $detailed_descriptions]
           aggregation_specs:
-            pmid:
+            study_references:
               group_by: nct_id
               alias: literature
+              struct:
+                id: pmid
+                type: reference_type
+              agg: unique
 
     generate:
       filtered_report:

--- a/src/clinical_mining/recipe/clinical_report_generation.yaml
+++ b/src/clinical_mining/recipe/clinical_report_generation.yaml
@@ -191,9 +191,13 @@ workflow:
           conditions: $conditions
           additional_metadata: ['$study_references', '$designs', '$brief_summaries', '$lead_sponsors', '$detailed_descriptions_rename']
           aggregation_specs:
-            pmid:
+            study_references:
               group_by: nct_id
               alias: literature
+              struct:
+                id: pmid
+                type: reference_type
+              agg: unique
             sponsor:
               group_by: nct_id
               alias: sponsor

--- a/tests/test_aact.py
+++ b/tests/test_aact.py
@@ -253,3 +253,41 @@ def test_extract_clinical_report_with_sponsors():
         "trialSponsor"
     ].to_list()[0]
     assert trial_sponsor_nct0001 == {"agencyClass": "INDUSTRY", "name": "Sponsor A"}
+
+
+def test_extract_clinical_report_with_study_references():
+    from clinical_mining.data_sources.aact import extract_clinical_report
+
+    study_references = pl.DataFrame(
+        {
+            "nct_id": ["NCT0001", "NCT0001", "NCT0001", "NCT0002"],
+            "pmid": [12345678, 99999999, 12345678, 11111111],
+            "reference_type": ["result", "background", "result", "result"],
+        }
+    )
+
+    aggregation_specs = {
+        "study_references": {
+            "group_by": "nct_id",
+            "alias": "literature",
+            "struct": {
+                "id": "pmid",
+                "type": "reference_type",
+            },
+            "agg": "unique",
+        }
+    }
+
+    result = extract_clinical_report(
+        studies=_make_studies(),
+        interventions=_make_interventions(),
+        conditions=_make_conditions(),
+        additional_metadata=[study_references],
+        aggregation_specs=aggregation_specs,
+    )
+
+    assert "trialLiterature" in result.df.columns
+    assert sorted(result.df["trialLiterature"].to_list()[0], key=lambda x: x["id"]) == [
+        {"id": "12345678", "type": "result"},
+        {"id": "99999999", "type": "background"},
+    ]

--- a/tests/test_pubmed.py
+++ b/tests/test_pubmed.py
@@ -131,8 +131,17 @@ def test_fetch_publications_retries_on_incomplete_read(capsys):
 
 def test_build_publications_map_basic():
     records = [
-        {"id": "NCT00000001", "trialLiterature": [12345678, 99999999]},
-        {"id": "NCT00000002", "trialLiterature": [12345678]},
+        {
+            "id": "NCT00000001",
+            "trialLiterature": [
+                {"id": "12345678", "type": "result"},
+                {"id": "99999999", "type": "background"},
+            ],
+        },
+        {
+            "id": "NCT00000002",
+            "trialLiterature": [{"id": "12345678", "type": "result"}],
+        },
         {"id": "NCT00000003", "trialLiterature": None},
     ]
     pub_data = {
@@ -151,7 +160,12 @@ def test_build_publications_map_basic():
 
 
 def test_build_publications_map_respects_max_pubs():
-    records = [{"id": "NCT00000001", "trialLiterature": [1, 2, 3, 4, 5]}]
+    records = [
+        {
+            "id": "NCT00000001",
+            "trialLiterature": [{"id": str(i), "type": "result"} for i in range(1, 6)],
+        }
+    ]
     pub_data = {
         str(i): {"title": f"Paper {i}", "abstractText": f"Abs {i}"} for i in range(1, 6)
     }
@@ -165,8 +179,20 @@ def test_build_publications_map_respects_max_pubs():
 
 def test_build_publications_map_deduplicates_pmids():
     records = [
-        {"id": "NCT00000001", "trialLiterature": [111, 222]},
-        {"id": "NCT00000002", "trialLiterature": [222, 333]},
+        {
+            "id": "NCT00000001",
+            "trialLiterature": [
+                {"id": "111", "type": "result"},
+                {"id": "222", "type": "background"},
+            ],
+        },
+        {
+            "id": "NCT00000002",
+            "trialLiterature": [
+                {"id": "222", "type": "result"},
+                {"id": "333", "type": "result"},
+            ],
+        },
     ]
     with patch(
         "clinical_mining.data_sources.pubmed.fetch_publications", return_value={}


### PR DESCRIPTION
Context: https://github.com/opentargets/clinical_mining/pull/59

This PR includes necessary changes to reshape how we store literature references from AACT.
We go from: `('trialLiterature', List(String))` to: `('trialLiterature', List(Struct({'id': String, 'type': String})))`

**Missing**: Porting the changes to https://github.com/opentargets/pipeline